### PR TITLE
Implemented Physicians Delete Functionalities. Closes #23

### DIFF
--- a/MAUI.ChartingSystem/MainPage.xaml.cs
+++ b/MAUI.ChartingSystem/MainPage.xaml.cs
@@ -26,7 +26,7 @@ namespace MAUI.ChartingSystem
 
         private void DeletePatientClicked(object sender, EventArgs e)
         {
-            (BindingContext as MainViewModel)?.Delete();
+            (BindingContext as MainViewModel)?.DeletePatient();
         }
 
         private void ContentPage_NavigatedTo(object sender, NavigatedToEventArgs e)
@@ -41,7 +41,7 @@ namespace MAUI.ChartingSystem
 
         private void DeletePhysiciansClicked(object sender, EventArgs e)
         {
-
+            (BindingContext as MainViewModel)?.DeletePhysician();
         }
 
         private void EditAppointmentClicked(object sender, EventArgs e)

--- a/MAUI.ChartingSystem/ViewModels/MainViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/MainViewModel.cs
@@ -57,7 +57,7 @@ namespace MAUI.ChartingSystem.ViewModels
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        public void Delete()
+        public void DeletePatient()
         {
             if (SelectedPatient == null)
             {
@@ -65,6 +65,16 @@ namespace MAUI.ChartingSystem.ViewModels
             }
             ChartServiceProxy.Current.RemovePatient(SelectedPatient);
             NotifyPropertyChanged(nameof(Patients));
+        }
+
+        public void DeletePhysician()
+        {
+            if (SelectedPhysician == null)
+            {
+                return;
+            }
+            ChartServiceProxy.Current.RemovePhysician(SelectedPhysician);
+            NotifyPropertyChanged(nameof(Physicians));
         }
     }
 }


### PR DESCRIPTION
Refactor and add deletion methods in MainViewModel

Renamed the `Delete` method in `MainViewModel` to `DeletePatient` for clarity. Added a new `DeletePhysician` method to handle physician deletion and notify changes to the `Physicians` collection.

Updated `MainPage.xaml.cs` to use the renamed `DeletePatient` method in the `DeletePatientClicked` event handler. Added support for the new `DeletePhysician` method in the `DeletePhysiciansClicked` event handler.