### PR TITLE
Add Appointments page with navigation and ViewModel.

### DIFF
--- a/MAUI.ChartingSystem/AppShell.xaml
+++ b/MAUI.ChartingSystem/AppShell.xaml
@@ -20,6 +20,10 @@
         ContentTemplate="{DataTemplate view:Physicians}"
         Route="Physicians" />
     <ShellContent
+        Title="Appointments View"
+        ContentTemplate="{DataTemplate view:Appointments}"
+        Route="Appointments" />
+    <ShellContent
         Title="PatientDetail"
         ContentTemplate="{DataTemplate view:PatientView}"
         Route="Patient" />

--- a/MAUI.ChartingSystem/MAUI.ChartingSystem.csproj
+++ b/MAUI.ChartingSystem/MAUI.ChartingSystem.csproj
@@ -81,6 +81,9 @@
 	  <MauiXaml Update="Views\AddPhysician.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\Appointments.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\Patients.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/MAUI.ChartingSystem/MainPage.xaml
+++ b/MAUI.ChartingSystem/MainPage.xaml
@@ -107,6 +107,7 @@
             <Button Text="Add Appointment" Clicked="AddAppointmentClicked"/>
             <Button Text="Patients" Clicked="PatientsClicked"/>
             <Button Text="Physicians" Clicked="PhysiciansClicked"/>
+            <Button Text="Appointments" Clicked="AppointmentsClicked"/>
         </VerticalStackLayout>
     </ScrollView>
 

--- a/MAUI.ChartingSystem/MainPage.xaml.cs
+++ b/MAUI.ChartingSystem/MainPage.xaml.cs
@@ -65,5 +65,10 @@ namespace MAUI.ChartingSystem
         {
             await Shell.Current.GoToAsync("//Physicians");
         }
+
+        private async void AppointmentsClicked(object sender, EventArgs e)
+        {
+            await Shell.Current.GoToAsync("//Appointments");
+        }
     }
 }

--- a/MAUI.ChartingSystem/ViewModels/AddAppointmentViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/AddAppointmentViewModel.cs
@@ -130,7 +130,7 @@ namespace MAUI.ChartingSystem.ViewModels
                     // Try updating appointment
                     ChartServiceProxy.Current.UpdateAppointment(_appointment, Patient, Physician, SelectedDateTime);
                     Shell.Current.DisplayAlert("Success", "Appointment updated successfully!", "OK");
-                    Shell.Current.GoToAsync("//MainPage");
+                    Shell.Current.GoToAsync("//Appointments");
                 }
                 // If doing create
                 else
@@ -140,7 +140,7 @@ namespace MAUI.ChartingSystem.ViewModels
                     {
                         ChartServiceProxy.Current.ScheduleAppointment(new Appointment(Patient, Physician, SelectedDateTime));
                         Shell.Current.DisplayAlert("Success", "Appointment added successfully!", "OK");
-                        Shell.Current.GoToAsync("//MainPage");
+                        Shell.Current.GoToAsync("//Appointments");
                     }
                     else
                     {

--- a/MAUI.ChartingSystem/ViewModels/AppointmentsViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/AppointmentsViewModel.cs
@@ -1,0 +1,71 @@
+﻿using Library.ChartingSystem.Models;
+using Library.ChartingSystem.Services;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace MAUI.ChartingSystem.ViewModels
+{
+    public class AppointmentsViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public ObservableCollection<Appointment> Appointments
+        {
+            get
+            {
+                return new ObservableCollection<Appointment>(ChartServiceProxy.Current.GetAllAppointments());
+            }
+        }
+
+        public AppointmentsViewModel()
+        {
+            SetUpCommands();
+        }
+
+        public ICommand? DeleteAppointmentCommand { get; set; }
+        public ICommand? EditAppointmentCommand { get; set; }
+
+        public void Refresh()
+        {
+            NotifyPropertyChanged(nameof(Appointments));
+        }
+
+        private void SetUpCommands()
+        {
+            DeleteAppointmentCommand = new Command<Appointment>(async (appt) => await DeleteAppointment(appt));
+            EditAppointmentCommand = new Command<Appointment>(async (appt) => await EditAppointment(appt));
+        }
+
+        private async Task DeleteAppointment(Appointment appointment)
+        {
+            if (appointment == null)
+                return;
+
+            bool confirm = await App.Current.MainPage.DisplayAlert("Confirm", $"Delete {appointment.Display}?", "Yes", "No");
+
+            if (confirm)
+                ChartServiceProxy.Current.CancelAppointment(appointment);
+            NotifyPropertyChanged(nameof(Appointments));
+        }
+
+        private async Task EditAppointment(Appointment appointment)
+        {
+            if (appointment == null)
+                return;
+
+            await Shell.Current.GoToAsync($"//Appointment?appointmentId={appointment.Id}");
+        }
+
+        private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/MAUI.ChartingSystem/ViewModels/PatientsViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/PatientsViewModel.cs
@@ -34,8 +34,8 @@ namespace MAUI.ChartingSystem.ViewModels
             NotifyPropertyChanged(nameof(Patients));
         }
 
-        public ICommand? DeletePatientsClicked {  get; set; }
-        public ICommand? EditPatientsClicked { get; set; }
+        public ICommand? DeletePatientCommand {  get; set; }
+        public ICommand? EditPatientCommand { get; set; }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {

--- a/MAUI.ChartingSystem/ViewModels/PhysiciansViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/PhysiciansViewModel.cs
@@ -35,8 +35,8 @@ namespace MAUI.ChartingSystem.ViewModels
             NotifyPropertyChanged(nameof(Physicians));
         }
 
-        public ICommand? DeletePatientsClicked { get; set; }
-        public ICommand? EditPatientsClicked { get; set; }
+        public ICommand? DeletePhysicianCommand { get; set; }
+        public ICommand? EditPhysicianCommand { get; set; }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {

--- a/MAUI.ChartingSystem/Views/AddAppointment.xaml.cs
+++ b/MAUI.ChartingSystem/Views/AddAppointment.xaml.cs
@@ -17,7 +17,7 @@ public partial class AppointmentView : ContentPage
 
     private void CancelClicked(object sender, EventArgs e)
     {
-        Shell.Current.GoToAsync("//MainPage");
+        Shell.Current.GoToAsync("//Appointments");
     }
 
     private void ContentPage_NavigatedTo(object sender, NavigatedToEventArgs e)

--- a/MAUI.ChartingSystem/Views/Appointments.xaml
+++ b/MAUI.ChartingSystem/Views/Appointments.xaml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MAUI.ChartingSystem.Views.Appointments"
+             Title="Appointments"
+             NavigatedTo="ContentPage_NavigatedTo">
+    <ScrollView>
+        <VerticalStackLayout Padding="30" Spacing="25">
+            <Label Text="Appointments Menu" FontSize="36" Style="{StaticResource HeaderLabel}" />
+            <Frame CornerRadius="10">
+                <StackLayout Spacing="24">
+                    <Label Text="Appointments List" FontSize="24" HorizontalOptions="Center"/>
+                    <ListView
+                    x:Name="AppointmentsListView"
+                    ItemsSource="{Binding Appointments}">
+                        <ListView.ItemTemplate>
+                            <DataTemplate>
+                                <ViewCell>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="5*"/>
+                                            <ColumnDefinition/>
+                                        </Grid.ColumnDefinitions>
+                                        <Label Text="{Binding Display}" Grid.Column="0"/>
+                                        <Grid Grid.Column="1">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition/>
+                                                <ColumnDefinition/>
+                                            </Grid.ColumnDefinitions>
+                                            <Button Command="{Binding BindingContext.EditAppointmentCommand, Source={x:Reference Name=AppointmentsListView}}"
+                                                CommandParameter="{Binding .}" Text="Edit" Grid.Column="0" Style="{StaticResource SecondaryButton}"/>
+                                            <Button Command="{Binding BindingContext.DeleteAppointmentCommand, Source={x:Reference Name=AppointmentsListView}}" 
+                                                CommandParameter="{Binding .}" Text="Delete" Grid.Column="1" Style="{StaticResource PrimaryButton}"/>
+                                        </Grid>
+                                    </Grid>
+                                </ViewCell>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </StackLayout>
+            </Frame>
+            <Grid ColumnSpacing="50">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*"/>
+                    <ColumnDefinition Width="2*"/>
+                </Grid.ColumnDefinitions>
+                <Button Text="Back" Clicked="BackClicked" Grid.Column="0" Style="{StaticResource SecondaryButton}"/>
+                <Button Text="Add" Clicked="AddClicked" Grid.Column="1" Style="{StaticResource PrimaryButton}"/>
+            </Grid>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/MAUI.ChartingSystem/Views/Appointments.xaml.cs
+++ b/MAUI.ChartingSystem/Views/Appointments.xaml.cs
@@ -1,0 +1,35 @@
+using MAUI.ChartingSystem.ViewModels;
+
+namespace MAUI.ChartingSystem.Views;
+
+public partial class Appointments : ContentPage
+{
+	private AppointmentsViewModel? _viewModel;
+	public Appointments()
+	{
+		InitializeComponent();
+	}
+
+    private void ContentPage_NavigatedTo(object sender, NavigatedToEventArgs e)
+    {
+        if (_viewModel is null)
+        {
+		    _viewModel = new AppointmentsViewModel();
+		    BindingContext = _viewModel;
+        }
+        else
+        {
+            _viewModel.Refresh();
+        }
+    }
+
+    private async void BackClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync("//MainPage");
+    }
+
+    private async void AddClicked(object sender, EventArgs e)
+    {
+        await Shell.Current.GoToAsync("//Appointment?appointmentId=0");
+    }
+}


### PR DESCRIPTION
Introduced a new Appointments page to manage appointments, including UI, navigation, and ViewModel logic. Updated `AppShell.xaml` to include navigation to the Appointments page. Added a button and event handler in `MainPage` for navigation.

Refactored `PatientsViewModel` and  PhysiciansViewModel` to improve command naming consistency. Updated `AddAppointmentViewModel` and `AddAppointment.xaml.cs` to navigate to the Appointments page after operations.

Created `AppointmentsViewModel` to handle appointment data and commands for editing and deleting appointments. Added `Appointments.xaml` and `Appointments.xaml.cs` for the Appointments page UI and code-behind. Updated the project file to include the new Appointments page.

Closes #44