### PR TITLE
Refactored Clicked Event Handlers to Commands for Delete Patients and…

### DIFF
--- a/MAUI.ChartingSystem/ViewModels/AppointmentsViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/AppointmentsViewModel.cs
@@ -51,8 +51,10 @@ namespace MAUI.ChartingSystem.ViewModels
             bool confirm = await App.Current.MainPage.DisplayAlert("Confirm", $"Delete {appointment.Display}?", "Yes", "No");
 
             if (confirm)
+            {
                 ChartServiceProxy.Current.CancelAppointment(appointment);
-            NotifyPropertyChanged(nameof(Appointments));
+                NotifyPropertyChanged(nameof(Appointments));
+            }
         }
 
         private async Task EditAppointment(Appointment appointment)

--- a/MAUI.ChartingSystem/ViewModels/PatientsViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/PatientsViewModel.cs
@@ -27,6 +27,7 @@ namespace MAUI.ChartingSystem.ViewModels
 
         public PatientsViewModel()
         {
+            SetUpCommands();
         }
 
         public void Refresh()
@@ -36,6 +37,25 @@ namespace MAUI.ChartingSystem.ViewModels
 
         public ICommand? DeletePatientCommand {  get; set; }
         public ICommand? EditPatientCommand { get; set; }
+
+        private void SetUpCommands()
+        {
+            DeletePatientCommand = new Command<Patient>(async (patient) => await DeletePatient(patient));
+        }
+
+        private async Task DeletePatient(Patient patient)
+        {
+            if (patient == null)
+                return;
+
+            bool confirm = await App.Current.MainPage.DisplayAlert("Confirm", $"Delete {patient.Display}?", "Yes", "No");
+
+            if (confirm)
+            {
+                ChartServiceProxy.Current.RemovePatient(patient);
+                NotifyPropertyChanged(nameof(Patients));
+            }
+        }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {

--- a/MAUI.ChartingSystem/ViewModels/PhysiciansViewModel.cs
+++ b/MAUI.ChartingSystem/ViewModels/PhysiciansViewModel.cs
@@ -28,6 +28,7 @@ namespace MAUI.ChartingSystem.ViewModels
 
         public PhysiciansViewModel()
         {
+            SetUpCommands();
         }
 
         public void Refresh()
@@ -37,6 +38,25 @@ namespace MAUI.ChartingSystem.ViewModels
 
         public ICommand? DeletePhysicianCommand { get; set; }
         public ICommand? EditPhysicianCommand { get; set; }
+
+        private void SetUpCommands()
+        {
+            DeletePhysicianCommand = new Command<Physician>(async (physician) => await DeletePhysician(physician));
+        }
+
+        private async Task DeletePhysician(Physician physician)
+        {
+            if (physician == null)
+                return;
+
+            bool confirm = await App.Current.MainPage.DisplayAlert("Confirm", $"Delete {physician.Display}?", "Yes", "No");
+
+            if (confirm)
+            {
+                ChartServiceProxy.Current.RemovePhysician(physician);
+                NotifyPropertyChanged(nameof(Physicians));
+            }
+        }
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {

--- a/MAUI.ChartingSystem/Views/Patients.xaml
+++ b/MAUI.ChartingSystem/Views/Patients.xaml
@@ -28,7 +28,8 @@
                                                 <ColumnDefinition/>
                                             </Grid.ColumnDefinitions>
                                             <Button Text="Edit" Grid.Column="0" Style="{StaticResource SecondaryButton}"/>
-                                            <Button Text="Delete" Grid.Column="1" Style="{StaticResource PrimaryButton}"/>
+                                            <Button Command="{Binding BindingContext.DeletePatientCommand, Source={x:Reference Name=PatientsListView}}"
+                                                    CommandParameter="{Binding .}" Text="Delete" Grid.Column="1" Style="{StaticResource PrimaryButton}"/>
                                         </Grid>
                                     </Grid>
                                 </ViewCell>

--- a/MAUI.ChartingSystem/Views/Physicians.xaml
+++ b/MAUI.ChartingSystem/Views/Physicians.xaml
@@ -28,7 +28,8 @@
                                                 <ColumnDefinition/>
                                             </Grid.ColumnDefinitions>
                                             <Button Text="Edit" Grid.Column="0" Style="{StaticResource SecondaryButton}"/>
-                                            <Button Text="Delete" Grid.Column="1" Style="{StaticResource PrimaryButton}"/>
+                                            <Button Command="{Binding BindingContext.DeletePhysicianCommand, Source={x:Reference Name=PhysiciansListView}}"
+                                                CommandParameter="{Binding .}" Text="Delete" Grid.Column="1" Style="{StaticResource PrimaryButton}"/>
                                         </Grid>
                                     </Grid>
                                 </ViewCell>


### PR DESCRIPTION
… Physicians. Closes #35

Add delete confirmation and command bindings

Added confirmation dialogs for deleting patients and physicians. Introduced `DeletePatientCommand` and `DeletePhysicianCommand` in their respective view models, along with `SetUpCommands` methods for initialization. Updated `Patients.xaml` and `Physicians.xaml` to bind delete buttons to the new commands with appropriate `CommandParameter` values. Ensured property change notifications are triggered only after successful deletions.